### PR TITLE
fix _ in multiline titles

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,9 @@
+0.7.5 (September 2, 2021)
+- The encoding for all python source files was changed to UTF8. A mis-encoded python file caused a problem with mdashes in titles.
+- multi-line titles had _ instead of \r. This was a relic of the hack needed to pass the title from python to PHP
+- updated ebookmaker and libgutenberg requirements
+
+
 0.7.4 (August 26, 2021)
 - add cron-csv-catalog.sh
 - updadate cron-dopush.sh to omit redundant sourcing

--- a/Pipfile
+++ b/Pipfile
@@ -17,8 +17,8 @@ rdflib = "*"
 qrcode = "*"
 ebookconverter = {editable = true,path = "."}
 pylint = "*"
-ebookmaker = "==0.11.3"
-libgutenberg = "==0.8.6"
+ebookmaker = "==0.11.7"
+libgutenberg = ">=0.8.7"
 
 [requires]
 python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "33bb5541d496510c507fda94ff3724315b864dedd2a44e904c1835f19f7dce0e"
+            "sha256": "1b8b0acf326ca7031aa1876f8671b3b304f665ee1b0ccbf908bc5a98683c5a1d"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,10 +18,10 @@
     "default": {
         "astroid": {
             "hashes": [
-                "sha256:b6c2d75cd7c2982d09e7d41d70213e863b3ba34d3bd4014e08f167cee966e99e",
-                "sha256:ecc50f9b3803ebf8ea19aa2c6df5622d8a5c31456a53c741d3be044d96ff0948"
+                "sha256:3b680ce0419b8a771aba6190139a3998d14b413852506d99aff8dc2bf65ee67c",
+                "sha256:dc1e8b28427d6bbef6b8842b18765ab58f558c42bb80540bd7648c98412af25e"
             ],
-            "version": "==2.7.2"
+            "version": "==2.7.3"
         },
         "cairocffi": {
             "hashes": [
@@ -139,10 +139,10 @@
         },
         "ebookmaker": {
             "hashes": [
-                "sha256:8ec378fea55788deada72318339493a204f5de57dff551229ab3860b1e132a3d"
+                "sha256:6bc92f3a50ac88b469670cf9bae809b58648b5406aa223e2d0b5d8a5352703c7"
             ],
             "index": "pypi",
-            "version": "==0.11.3"
+            "version": "==0.11.7"
         },
         "greenlet": {
             "hashes": [
@@ -210,11 +210,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:7b30a78db2922d78a6f47fb30683156a14f3c6aa5cc23f77cc8967e9ab2d002f",
-                "sha256:ed5157fef23a4bc4594615a0dd8eba94b2bb36bf2a343fa3d8bb2fa0a62a99d5"
+                "sha256:b618b6d2d5ffa2f16add5697cf57a46c76a56229b0ed1c438322e4e95645bd15",
+                "sha256:f284b3e11256ad1e5d03ab86bb2ccd6f5339688ff17a4d797a0fe7df326f23b1"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==4.6.4"
+            "version": "==4.8.1"
         },
         "importlib-resources": {
             "hashes": [
@@ -306,10 +306,10 @@
                 "postgres"
             ],
             "hashes": [
-                "sha256:a3efbcaa04bd79df5fb44bd9b21be45e79129c1c37581173e4e23d3b45c844c9"
+                "sha256:96b4fedb9691d2f0e9c7f9c6fc154c37743fc55870efba3f3025e7d75978a5a3"
             ],
             "index": "pypi",
-            "version": "==0.8.6"
+            "version": "==0.8.7"
         },
         "lxml": {
             "hashes": [
@@ -431,10 +431,10 @@
         },
         "platformdirs": {
             "hashes": [
-                "sha256:4666d822218db6a262bdfdc9c39d21f23b4cfdb08af331a81e92751daf6c866c",
-                "sha256:632daad3ab546bd8e6af0537d09805cec458dce201bccfe23012df73332e181e"
+                "sha256:15b056538719b1c94bdaccb29e5f81879c7f7f0f4a153f46086d155dffcd4f0f",
+                "sha256:8003ac87717ae2c7ee1ea5a84a1a61e87f3fbd16eb5aadba194ea30a9019f648"
             ],
-            "version": "==2.2.0"
+            "version": "==2.3.0"
         },
         "portend": {
             "hashes": [
@@ -632,12 +632,12 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497",
-                "sha256:50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342",
-                "sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84"
+                "sha256:49f75d16ff11f1cd258e1b988ccff82a3ca5570217d7ad8c5f48205dd99a677e",
+                "sha256:d8226d10bc02a29bcc81df19a26e56a9647f8b0a6d4a83924139f4a8b01f17b7",
+                "sha256:f1d25edafde516b146ecd0613dabcc61409817af4766fbbcfb8d1ad4ec441a34"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==3.10.0.0"
+            "version": "==3.10.0.2"
         },
         "urllib3": {
             "hashes": [
@@ -671,10 +671,10 @@
     "develop": {
         "astroid": {
             "hashes": [
-                "sha256:b6c2d75cd7c2982d09e7d41d70213e863b3ba34d3bd4014e08f167cee966e99e",
-                "sha256:ecc50f9b3803ebf8ea19aa2c6df5622d8a5c31456a53c741d3be044d96ff0948"
+                "sha256:3b680ce0419b8a771aba6190139a3998d14b413852506d99aff8dc2bf65ee67c",
+                "sha256:dc1e8b28427d6bbef6b8842b18765ab58f558c42bb80540bd7648c98412af25e"
             ],
-            "version": "==2.7.2"
+            "version": "==2.7.3"
         },
         "isort": {
             "hashes": [
@@ -719,10 +719,10 @@
         },
         "platformdirs": {
             "hashes": [
-                "sha256:4666d822218db6a262bdfdc9c39d21f23b4cfdb08af331a81e92751daf6c866c",
-                "sha256:632daad3ab546bd8e6af0537d09805cec458dce201bccfe23012df73332e181e"
+                "sha256:15b056538719b1c94bdaccb29e5f81879c7f7f0f4a153f46086d155dffcd4f0f",
+                "sha256:8003ac87717ae2c7ee1ea5a84a1a61e87f3fbd16eb5aadba194ea30a9019f648"
             ],
-            "version": "==2.2.0"
+            "version": "==2.3.0"
         },
         "pylint": {
             "hashes": [
@@ -777,12 +777,12 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497",
-                "sha256:50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342",
-                "sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84"
+                "sha256:49f75d16ff11f1cd258e1b988ccff82a3ca5570217d7ad8c5f48205dd99a677e",
+                "sha256:d8226d10bc02a29bcc81df19a26e56a9647f8b0a6d4a83924139f4a8b01f17b7",
+                "sha256:f1d25edafde516b146ecd0613dabcc61409817af4766fbbcfb8d1ad4ec441a34"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==3.10.0.0"
+            "version": "==3.10.0.2"
         },
         "v": {
             "hashes": [

--- a/ebookconverter/AutoDelete.py
+++ b/ebookconverter/AutoDelete.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-#  -*- mode: python; indent-tabs-mode: nil; -*- coding: iso-8859-1 -*-
+#  -*- mode: python; indent-tabs-mode: nil; -*- coding: UTF8 -*-
 
 """
 

--- a/ebookconverter/Candidates.py
+++ b/ebookconverter/Candidates.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#  -*- mode: python; indent-tabs-mode: nil; -*- coding: iso-8859-1 -*-
+#  -*- mode: python; indent-tabs-mode: nil; -*- coding: UTF8 -*-
 
 """
 

--- a/ebookconverter/EbookConverter.py
+++ b/ebookconverter/EbookConverter.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#  -*- mode: python; indent-tabs-mode: nil; -*- coding: iso-8859-1 -*-
+#  -*- mode: python; indent-tabs-mode: nil; -*- coding: UTF8 -*-
 
 """
 EbookConverter.py

--- a/ebookconverter/FileInfo.py
+++ b/ebookconverter/FileInfo.py
@@ -67,7 +67,7 @@ def save_metadata(dc):
     """ Save the metadata. """
 
     if dc.title:
-        dc.title = re.sub (r'\s*\n\s*', ' _ ', dc.title.strip ())
+        dc.title = re.sub (r'\s*\n\s*', '\n', dc.title.strip ())
 
     if dc.rights.lower ().find ('copyright') > -1:
         dc.rights = 1 # ???

--- a/ebookconverter/FileInfo.py
+++ b/ebookconverter/FileInfo.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-#  -*- mode: python; indent-tabs-mode: nil; -*- coding: iso-8859-1 -*-
+#  -*- mode: python; indent-tabs-mode: nil; -*- coding: UTF8 -*-
 
 """
 

--- a/ebookconverter/Version.py
+++ b/ebookconverter/Version.py
@@ -1,1 +1,1 @@
-VERSION = '0.7.4'
+VERSION = '0.7.5'

--- a/ebookconverter/writers/CoverWriter.py
+++ b/ebookconverter/writers/CoverWriter.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#  -*- mode: python; indent-tabs-mode: nil; -*- coding: iso-8859-1 -*-
+#  -*- mode: python; indent-tabs-mode: nil; -*- coding: UTF8 -*-
 
 """
 

--- a/ebookconverter/writers/QRCodeWriter.py
+++ b/ebookconverter/writers/QRCodeWriter.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#  -*- mode: python; indent-tabs-mode: nil; -*- coding: iso-8859-1 -*-
+#  -*- mode: python; indent-tabs-mode: nil; -*- coding: UTF8 -*-
 
 """
 

--- a/scripts/autodelete
+++ b/scripts/autodelete
@@ -1,5 +1,5 @@
 #!/public/vhost/g/gutenberg/local/bin/python3.6
-#  -*- mode: python; indent-tabs-mode: nil; -*- coding: iso-8859-1 -*-
+#  -*- mode: python; indent-tabs-mode: nil; -*- coding: UTF8 -*-
 
 """
 

--- a/scripts/ebookconverter
+++ b/scripts/ebookconverter
@@ -1,5 +1,5 @@
 #!/public/vhost/g/gutenberg/local/bin/python3.6
-#  -*- mode: python; indent-tabs-mode: nil; -*- coding: iso-8859-1 -*-
+#  -*- mode: python; indent-tabs-mode: nil; -*- coding: UTF8 -*-
 
 """
 

--- a/scripts/fileinfo
+++ b/scripts/fileinfo
@@ -1,5 +1,5 @@
 #!/public/vhost/g/gutenberg/local/bin/python3.6
-#  -*- mode: python; indent-tabs-mode: nil; -*- coding: iso-8859-1 -*-
+#  -*- mode: python; indent-tabs-mode: nil; -*- coding: UTF8 -*-
 
 """
 

--- a/scripts/fileinfo_debug
+++ b/scripts/fileinfo_debug
@@ -1,5 +1,5 @@
 #!/public/vhost/g/gutenberg/local/bin/python3.6
-#  -*- mode: python; indent-tabs-mode: nil; -*- coding: iso-8859-1 -*-
+#  -*- mode: python; indent-tabs-mode: nil; -*- coding: UTF8 -*-
 
 """
 

--- a/scripts/make_csv
+++ b/scripts/make_csv
@@ -1,5 +1,5 @@
 #!/public/vhost/g/gutenberg/local/bin/python3.6
-#  -*- mode: python; indent-tabs-mode: nil; -*- coding: iso-8859-1 -*-
+#  -*- mode: python; indent-tabs-mode: nil; -*- coding: UTF8 -*-
 
 """
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 
 from setuptools import setup
 
-VERSION = '0.7.4'
+VERSION = '0.7.5'
 
 setup (
     name = 'ebookconverter',
@@ -26,12 +26,12 @@ setup (
     ],
 
     install_requires = [
-        'ebookmaker>=0.11.3',
+        'ebookmaker>=0.11.7',
         'setproctitle==1.1.10',
         'requests_oauthlib>=1.2.0',
         'rdflib>=4.2.2',
         'qrcode>=6.1',
-        'libgutenberg[postgres]>=0.8.6',
+        'libgutenberg[postgres]>=0.8.7',
     ],
     
     package_data = {


### PR DESCRIPTION
0.7.5 (September 2, 2021)
- The encoding for all python source files was changed to UTF8. A mis-encoded python file caused a problem with mdashes in titles.
- multi-line titles had _ instead of \r. This was a relic of the hack needed to pass the title from python to PHP
- updated ebookmaker and libgutenberg requirements
