### PR TITLE
add UpdateWriter

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,6 @@
 0.8.1
+- when the html file is large (>16M), in most cases we don't really want to make an EPUB or a MOBI. Making the MOBI can take hours with our current infrastructure. Changed the source file size filters  so these formats are not made.
+- when the source EPUBs are >32M, only old-format MOBIs are not made.
 - add jekyll script
 - stop trying to store qr codes in database
 

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,5 @@
+- stop trying to store qr codes in database
+
 0.8.0 (August 18, 2022)
 - production directory moves from ~/converter to ~/ebookconverter to accomplish the python version migration.
 

--- a/CHANGES
+++ b/CHANGES
@@ -2,7 +2,8 @@
 - when the html file is large (>16M), in most cases we don't really want to make an EPUB or a MOBI. Making the MOBI can take hours with our current infrastructure. Changed the source file size filters  so these formats are not made.
 - when the source EPUBs are >32M, only old-format MOBIs are not made.
 - add jekyll script
-- stop trying to store qr codes in database
+- stop trying to store qr codes in databaseta from backup workflow files
+- add script to load metadata
 
 0.8.0 (August 18, 2022)
 - production directory moves from ~/converter to ~/ebookconverter to accomplish the python version migration.

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 0.8.2
 - Adds UpdateWriter. It scans source files for metadata headers and adds to the database. Currently only looks for 'Credit:' or 'Produced by:'.
 - `.xhtml` added to parseable file extensions
+- stop producing kindle.noimages unless asked to
 
 0.8.1 (September 14, 2022)
 - when the html file is large (>16M), in most cases we don't really want to make an EPUB or a MOBI. Making the MOBI can take hours with our current infrastructure. Changed the source file size filters  so these formats are not made.

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,5 @@
+0.8.1
+- add jekyll script
 - stop trying to store qr codes in database
 
 0.8.0 (August 18, 2022)

--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,7 @@
-0.8.1
+0.8.2
+- `.xhtml` added to parseable file extensions
+
+0.8.1 (September 14, 2022)
 - when the html file is large (>16M), in most cases we don't really want to make an EPUB or a MOBI. Making the MOBI can take hours with our current infrastructure. Changed the source file size filters  so these formats are not made.
 - when the source EPUBs are >32M, only old-format MOBIs are not made.
 - add jekyll script

--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,4 @@
-0.8.2
+0.8.2 (September 30, 2022)
 - Adds UpdateWriter. It scans source files for metadata headers and adds to the database. Currently only looks for 'Credit:' or 'Produced by:'.
 - `.xhtml` added to parseable file extensions
 - stop producing kindle.noimages unless asked to

--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,5 @@
 0.8.2
+- Adds UpdateWriter. It scans source files for metadata headers and adds to the database. Currently only looks for 'Credit:' or 'Produced by:'.
 - `.xhtml` added to parseable file extensions
 
 0.8.1 (September 14, 2022)

--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@
 - Adds UpdateWriter. It scans source files for metadata headers and adds to the database. Currently only looks for 'Credit:' or 'Produced by:'.
 - `.xhtml` added to parseable file extensions
 - stop producing kindle.noimages unless asked to
+- add a "generic" file name for Writers that don't write (Twiter, Facebook, Update)
 
 0.8.1 (September 14, 2022)
 - when the html file is large (>16M), in most cases we don't really want to make an EPUB or a MOBI. Making the MOBI can take hours with our current infrastructure. Changed the source file size filters  so these formats are not made.

--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,8 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-libgutenberg = ">=0.10.2"
+libgutenberg = ">=0.10.3"
+ebookmaker = ">=0.12.14"
 ebookconverter = {editable = true, path = "."}
 
 [dev-packages]

--- a/Pipfile
+++ b/Pipfile
@@ -4,10 +4,10 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
+libgutenberg = ">=0.10.2"
 ebookconverter = {editable = true, path = "."}
-ebookmaker = ">=0.12.0b2"
 
 [dev-packages]
 
 [requires]
-python_version = "3.8"
+python_version = ">3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a6ff6f76b194ebb844e75adba9bbec52c72728da166335cfbd90d68bbcac94cc"
+            "sha256": "f37a18b3c29beb7bfa13dc6188c665ede97eea333a184a3d88059755b07daf24"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.9"
+            "python_version": ">3.7"
         },
         "sources": [
             {
@@ -73,11 +73,11 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:36973885b9542e6bd01dea287b2b4b3b21236307c56324fcc3f1160f2d655ed5",
-                "sha256:e232343de1ab72c2aa521b625c80f699e356830fd0e2c620b465b304b17b0516"
+                "sha256:0d9c601124e5a6ba9712dbc60d9c53c21e34f5f641fe83002317394311bdce14",
+                "sha256:90c1a32f1d68f940488354e36370f6cca89f0f106db09518524c88d6ed83f382"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2022.9.14"
+            "version": "==2022.9.24"
         },
         "cffi": {
             "hashes": [
@@ -194,9 +194,10 @@
         },
         "ebookmaker": {
             "hashes": [
-                "sha256:5992e1adb756f2aa8d6202822a93ea00832a9a8ad48554f458c6fbabcb009a3e"
+                "sha256:e4ad32247c36e12d0fd435afd2b1bb4dbab7a74c3e0ef23b02edeec3acc02e67"
             ],
-            "version": "==0.12.8"
+            "index": "pypi",
+            "version": "==0.12.14"
         },
         "greenlet": {
             "hashes": [
@@ -283,11 +284,11 @@
         },
         "jaraco.classes": {
             "hashes": [
-                "sha256:6745f113b0b588239ceb49532aa09c3ebb947433ce311ef2f8e3ad64ebb74594",
-                "sha256:e6ef6fd3fcf4579a7a019d87d1e56a883f4e4c35cfe925f86731abc58804e647"
+                "sha256:2353de3288bc6b82120752201c6b1c1a14b058267fa424ed5ce5984e3b922158",
+                "sha256:89559fa5c1d3c34eff6f631ad80bb21f378dbcbb35dd161fd2c6b93f5be2f98a"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.2.2"
+            "version": "==3.2.3"
         },
         "jaraco.collections": {
             "hashes": [
@@ -307,11 +308,11 @@
         },
         "jaraco.functools": {
             "hashes": [
-                "sha256:c8774f73323de42250a659934215da1d899b02c66a6133f1cb79f02a5aff4f38",
-                "sha256:d0adcf91710a0853efe9f23a78fad586bf67df572f0d6d8e0fa36d289ae1c1d9"
+                "sha256:163d6369dd2fc6590712677cbf83b06ee0e4a1a0c720f4b377eae04175ce458e",
+                "sha256:45b05c158f3ad28731075556ffd4749bd254ec67f91e1eb367dcfebff1151db4"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.5.1"
+            "version": "==3.5.2"
         },
         "jaraco.text": {
             "hashes": [
@@ -322,11 +323,12 @@
             "version": "==3.9.1"
         },
         "libgutenberg": {
+            "extras": [],
             "hashes": [
-                "sha256:ecf27e4bca5c265d1c37d2187ddec667079c96d53f5eb7e98555e3446754da22"
+                "sha256:6714996f1ffe55889a5c7aeef9e50dfbc9b8900fa6d3098accd86f112c2a81eb"
             ],
             "index": "pypi",
-            "version": "==0.10.2"
+            "version": "==0.10.4"
         },
         "lxml": {
             "hashes": [
@@ -627,11 +629,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:2e24e0bec025f035a2e72cdd1961119f557d78ad331bb00ff82efb2ab8da8e82",
-                "sha256:7732871f4f7fa58fb6bdcaeadb0161b2bd046c85905dbaa066bdcbcc81953b57"
+                "sha256:1b6bdc6161661409c5f21508763dc63ab20a9ac2f8ba20029aaaa7fdb9118012",
+                "sha256:3050e338e5871e70c72983072fe34f6032ae1cdeeeb67338199c2f74e083a80e"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==65.3.0"
+            "version": "==65.4.1"
         },
         "six": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e77d1d15dd395207b5eab402eb85d4ebc25b6263a03f1a15a30aad3541b920a6"
+            "sha256": "a6ff6f76b194ebb844e75adba9bbec52c72728da166335cfbd90d68bbcac94cc"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.8"
+            "python_version": "3.9"
         },
         "sources": [
             {
@@ -16,6 +16,13 @@
         ]
     },
     "default": {
+        "autocommand": {
+            "hashes": [
+                "sha256:85d03044c2a1fc1c7844ac41545045927aecde0cbaf8ea28b88e0cd8588ce5d3",
+                "sha256:fed420e9d02745821a782971b583c6970259ee0b229be2a0a401e1467a4f170f"
+            ],
+            "version": "==2.2.1"
+        },
         "beautifulsoup4": {
             "hashes": [
                 "sha256:58d5c3d29f5a36ffeb94f02f0d786cd53014cf9b3b3951d42e0080d8a9498d30",
@@ -23,14 +30,6 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==4.11.1"
-        },
-        "bleach": {
-            "hashes": [
-                "sha256:085f7f33c15bd408dd9b17a4ad77c577db66d76203e5984b1bd59baeee948b2a",
-                "sha256:0d03255c47eb9bd2f26aa9bb7f2107732e7e8fe195ca2f64709fcf3b0a4a085c"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==5.0.1"
         },
         "cairocffi": {
             "hashes": [
@@ -74,11 +73,11 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d",
-                "sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412"
+                "sha256:36973885b9542e6bd01dea287b2b4b3b21236307c56324fcc3f1160f2d655ed5",
+                "sha256:e232343de1ab72c2aa521b625c80f699e356830fd0e2c620b465b304b17b0516"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2022.6.15"
+            "version": "==2022.9.14"
         },
         "cffi": {
             "hashes": [
@@ -151,11 +150,11 @@
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:5189b6f22b01957427f35b6a08d9a0bc45b46d3788ef5a92e978433c7a35f8a5",
-                "sha256:575e708016ff3a5e3681541cb9d79312c416835686d054a23accb873b254f413"
+                "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845",
+                "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2.1.0"
+            "version": "==2.1.1"
         },
         "cheroot": {
             "hashes": [
@@ -173,20 +172,13 @@
             "markers": "python_version >= '3.6'",
             "version": "==18.8.0"
         },
-        "commonmark": {
-            "hashes": [
-                "sha256:452f9dc859be7f06631ddcb328b6919c67984aca654e5fefb3914d54691aed60",
-                "sha256:da2f38c92590f83de410ba1a3cbceafbc74fee9def35f9251ba9a971d6d66fd9"
-            ],
-            "version": "==0.9.1"
-        },
         "cssutils": {
             "hashes": [
-                "sha256:5b24b5e2d34a280d561b4b719c0eba6f8417a38dd5d967ac585eb5522d3d0786",
-                "sha256:b4a4da58e78326ec9f4a9d3555004ddf706f3e99f7a1026c1880f0934362b8b4"
+                "sha256:30c72f3a5c5951a11151640600aae7b3bf10e4c0d5c87f5bc505c2cd4a26e0c2",
+                "sha256:f7dcd23c1cec909fdf3630de346e1413b7b2555936dec14ba2ebb9913bf0818e"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.5.1"
+            "version": "==2.6.0"
         },
         "docutils": {
             "hashes": [
@@ -202,95 +194,85 @@
         },
         "ebookmaker": {
             "hashes": [
-                "sha256:d8c4d6bb6ab3671bfce8e5f06d7a0f279845a9642d980af70b84c2b39f0398ac"
+                "sha256:5992e1adb756f2aa8d6202822a93ea00832a9a8ad48554f458c6fbabcb009a3e"
             ],
-            "index": "pypi",
-            "version": "==0.12.0b2"
+            "version": "==0.12.8"
         },
         "greenlet": {
             "hashes": [
-                "sha256:0051c6f1f27cb756ffc0ffbac7d2cd48cb0362ac1736871399a739b2885134d3",
-                "sha256:00e44c8afdbe5467e4f7b5851be223be68adb4272f44696ee71fe46b7036a711",
-                "sha256:013d61294b6cd8fe3242932c1c5e36e5d1db2c8afb58606c5a67efce62c1f5fd",
-                "sha256:049fe7579230e44daef03a259faa24511d10ebfa44f69411d99e6a184fe68073",
-                "sha256:14d4f3cd4e8b524ae9b8aa567858beed70c392fdec26dbdb0a8a418392e71708",
-                "sha256:166eac03e48784a6a6e0e5f041cfebb1ab400b394db188c48b3a84737f505b67",
-                "sha256:17ff94e7a83aa8671a25bf5b59326ec26da379ace2ebc4411d690d80a7fbcf23",
-                "sha256:1e12bdc622676ce47ae9abbf455c189e442afdde8818d9da983085df6312e7a1",
-                "sha256:21915eb821a6b3d9d8eefdaf57d6c345b970ad722f856cd71739493ce003ad08",
-                "sha256:288c6a76705dc54fba69fbcb59904ae4ad768b4c768839b8ca5fdadec6dd8cfd",
-                "sha256:2bde6792f313f4e918caabc46532aa64aa27a0db05d75b20edfc5c6f46479de2",
-                "sha256:32ca72bbc673adbcfecb935bb3fb1b74e663d10a4b241aaa2f5a75fe1d1f90aa",
-                "sha256:356b3576ad078c89a6107caa9c50cc14e98e3a6c4874a37c3e0273e4baf33de8",
-                "sha256:40b951f601af999a8bf2ce8c71e8aaa4e8c6f78ff8afae7b808aae2dc50d4c40",
-                "sha256:572e1787d1460da79590bf44304abbc0a2da944ea64ec549188fa84d89bba7ab",
-                "sha256:58df5c2a0e293bf665a51f8a100d3e9956febfbf1d9aaf8c0677cf70218910c6",
-                "sha256:64e6175c2e53195278d7388c454e0b30997573f3f4bd63697f88d855f7a6a1fc",
-                "sha256:7227b47e73dedaa513cdebb98469705ef0d66eb5a1250144468e9c3097d6b59b",
-                "sha256:7418b6bfc7fe3331541b84bb2141c9baf1ec7132a7ecd9f375912eca810e714e",
-                "sha256:7cbd7574ce8e138bda9df4efc6bf2ab8572c9aff640d8ecfece1b006b68da963",
-                "sha256:7ff61ff178250f9bb3cd89752df0f1dd0e27316a8bd1465351652b1b4a4cdfd3",
-                "sha256:833e1551925ed51e6b44c800e71e77dacd7e49181fdc9ac9a0bf3714d515785d",
-                "sha256:8639cadfda96737427330a094476d4c7a56ac03de7265622fcf4cfe57c8ae18d",
-                "sha256:8c5d5b35f789a030ebb95bff352f1d27a93d81069f2adb3182d99882e095cefe",
-                "sha256:8c790abda465726cfb8bb08bd4ca9a5d0a7bd77c7ac1ca1b839ad823b948ea28",
-                "sha256:8d2f1fb53a421b410751887eb4ff21386d119ef9cde3797bf5e7ed49fb51a3b3",
-                "sha256:903bbd302a2378f984aef528f76d4c9b1748f318fe1294961c072bdc7f2ffa3e",
-                "sha256:93f81b134a165cc17123626ab8da2e30c0455441d4ab5576eed73a64c025b25c",
-                "sha256:95e69877983ea39b7303570fa6760f81a3eec23d0e3ab2021b7144b94d06202d",
-                "sha256:9633b3034d3d901f0a46b7939f8c4d64427dfba6bbc5a36b1a67364cf148a1b0",
-                "sha256:97e5306482182170ade15c4b0d8386ded995a07d7cc2ca8f27958d34d6736497",
-                "sha256:9f3cba480d3deb69f6ee2c1825060177a22c7826431458c697df88e6aeb3caee",
-                "sha256:aa5b467f15e78b82257319aebc78dd2915e4c1436c3c0d1ad6f53e47ba6e2713",
-                "sha256:abb7a75ed8b968f3061327c433a0fbd17b729947b400747c334a9c29a9af6c58",
-                "sha256:aec52725173bd3a7b56fe91bc56eccb26fbdff1386ef123abb63c84c5b43b63a",
-                "sha256:b11548073a2213d950c3f671aa88e6f83cda6e2fb97a8b6317b1b5b33d850e06",
-                "sha256:b1692f7d6bc45e3200844be0dba153612103db241691088626a33ff1f24a0d88",
-                "sha256:b336501a05e13b616ef81ce329c0e09ac5ed8c732d9ba7e3e983fcc1a9e86965",
-                "sha256:b8c008de9d0daba7b6666aa5bbfdc23dcd78cafc33997c9b7741ff6353bafb7f",
-                "sha256:b92e29e58bef6d9cfd340c72b04d74c4b4e9f70c9fa7c78b674d1fec18896dc4",
-                "sha256:be5f425ff1f5f4b3c1e33ad64ab994eed12fc284a6ea71c5243fd564502ecbe5",
-                "sha256:dd0b1e9e891f69e7675ba5c92e28b90eaa045f6ab134ffe70b52e948aa175b3c",
-                "sha256:e30f5ea4ae2346e62cedde8794a56858a67b878dd79f7df76a0767e356b1744a",
-                "sha256:e6a36bb9474218c7a5b27ae476035497a6990e21d04c279884eb10d9b290f1b1",
-                "sha256:e859fcb4cbe93504ea18008d1df98dee4f7766db66c435e4882ab35cf70cac43",
-                "sha256:eb6ea6da4c787111adf40f697b4e58732ee0942b5d3bd8f435277643329ba627",
-                "sha256:ec8c433b3ab0419100bd45b47c9c8551248a5aee30ca5e9d399a0b57ac04651b",
-                "sha256:eff9d20417ff9dcb0d25e2defc2574d10b491bf2e693b4e491914738b7908168",
-                "sha256:f0214eb2a23b85528310dad848ad2ac58e735612929c8072f6093f3585fd342d",
-                "sha256:f276df9830dba7a333544bd41070e8175762a7ac20350786b322b714b0e654f5",
-                "sha256:f3acda1924472472ddd60c29e5b9db0cec629fbe3c5c5accb74d6d6d14773478",
-                "sha256:f70a9e237bb792c7cc7e44c531fd48f5897961701cdaa06cf22fc14965c496cf",
-                "sha256:f9d29ca8a77117315101425ec7ec2a47a22ccf59f5593378fc4077ac5b754fce",
-                "sha256:fa877ca7f6b48054f847b61d6fa7bed5cebb663ebc55e018fda12db09dcc664c",
-                "sha256:fdcec0b8399108577ec290f55551d926d9a1fa6cad45882093a7a07ac5ec147b"
+                "sha256:0118817c9341ef2b0f75f5af79ac377e4da6ff637e5ee4ac91802c0e379dadb4",
+                "sha256:048d2bed76c2aa6de7af500ae0ea51dd2267aec0e0f2a436981159053d0bc7cc",
+                "sha256:07c58e169bbe1e87b8bbf15a5c1b779a7616df9fd3e61cadc9d691740015b4f8",
+                "sha256:095a980288fe05adf3d002fbb180c99bdcf0f930e220aa66fcd56e7914a38202",
+                "sha256:0b181e9aa6cb2f5ec0cacc8cee6e5a3093416c841ba32c185c30c160487f0380",
+                "sha256:1626185d938d7381631e48e6f7713e8d4b964be246073e1a1d15c2f061ac9f08",
+                "sha256:184416e481295832350a4bf731ba619a92f5689bf5d0fa4341e98b98b1265bd7",
+                "sha256:1dd51d2650e70c6c4af37f454737bf4a11e568945b27f74b471e8e2a9fd21268",
+                "sha256:1ec2779774d8e42ed0440cf8bc55540175187e8e934f2be25199bf4ed948cd9e",
+                "sha256:2cf45e339cabea16c07586306a31cfcc5a3b5e1626d365714d283732afed6809",
+                "sha256:2fb0aa7f6996879551fd67461d5d3ab0c3c0245da98be90c89fcb7a18d437403",
+                "sha256:44b4817c34c9272c65550b788913620f1fdc80362b209bc9d7dd2f40d8793080",
+                "sha256:466ce0928e33421ee84ae04c4ac6f253a3a3e6b8d600a79bd43fd4403e0a7a76",
+                "sha256:4f166b4aca8d7d489e82d74627a7069ab34211ef5ebb57c300ec4b9337b60fc0",
+                "sha256:510c3b15587afce9800198b4b142202b323bf4b4b5f9d6c79cb9a35e5e3c30d2",
+                "sha256:5b756e6730ea59b2745072e28ad27f4c837084688e6a6b3633c8b1e509e6ae0e",
+                "sha256:5fbe1ab72b998ca77ceabbae63a9b2e2dc2d963f4299b9b278252ddba142d3f1",
+                "sha256:6200a11f003ec26815f7e3d2ded01b43a3810be3528dd760d2f1fa777490c3cd",
+                "sha256:65ad1a7a463a2a6f863661329a944a5802c7129f7ad33583dcc11069c17e622c",
+                "sha256:694ffa7144fa5cc526c8f4512665003a39fa09ef00d19bbca5c8d3406db72fbe",
+                "sha256:6f5d4b2280ceea76c55c893827961ed0a6eadd5a584a7c4e6e6dd7bc10dfdd96",
+                "sha256:7532a46505470be30cbf1dbadb20379fb481244f1ca54207d7df3bf0bbab6a20",
+                "sha256:76a53bfa10b367ee734b95988bd82a9a5f0038a25030f9f23bbbc005010ca600",
+                "sha256:77e41db75f9958f2083e03e9dd39da12247b3430c92267df3af77c83d8ff9eed",
+                "sha256:7a43bbfa9b6cfdfaeefbd91038dde65ea2c421dc387ed171613df340650874f2",
+                "sha256:7b41d19c0cfe5c259fe6c539fd75051cd39a5d33d05482f885faf43f7f5e7d26",
+                "sha256:7c5227963409551ae4a6938beb70d56bf1918c554a287d3da6853526212fbe0a",
+                "sha256:870a48007872d12e95a996fca3c03a64290d3ea2e61076aa35d3b253cf34cd32",
+                "sha256:88b04e12c9b041a1e0bcb886fec709c488192638a9a7a3677513ac6ba81d8e79",
+                "sha256:8c287ae7ac921dfde88b1c125bd9590b7ec3c900c2d3db5197f1286e144e712b",
+                "sha256:903fa5716b8fbb21019268b44f73f3748c41d1a30d71b4a49c84b642c2fed5fa",
+                "sha256:9537e4baf0db67f382eb29255a03154fcd4984638303ff9baaa738b10371fa57",
+                "sha256:9951dcbd37850da32b2cb6e391f621c1ee456191c6ae5528af4a34afe357c30e",
+                "sha256:9b2f7d0408ddeb8ea1fd43d3db79a8cefaccadd2a812f021333b338ed6b10aba",
+                "sha256:9c88e134d51d5e82315a7c32b914a58751b7353eb5268dbd02eabf020b4c4700",
+                "sha256:9fae214f6c43cd47f7bef98c56919b9222481e833be2915f6857a1e9e8a15318",
+                "sha256:a3a669f11289a8995d24fbfc0e63f8289dd03c9aaa0cc8f1eab31d18ca61a382",
+                "sha256:aa741c1a8a8cc25eb3a3a01a62bdb5095a773d8c6a86470bde7f607a447e7905",
+                "sha256:b0877a9a2129a2c56a2eae2da016743db7d9d6a05d5e1c198f1b7808c602a30e",
+                "sha256:bcb6c6dd1d6be6d38d6db283747d07fda089ff8c559a835236560a4410340455",
+                "sha256:caff52cb5cd7626872d9696aee5b794abe172804beb7db52eed1fd5824b63910",
+                "sha256:cbc1eb55342cbac8f7ec159088d54e2cfdd5ddf61c87b8bbe682d113789331b2",
+                "sha256:cd16a89efe3a003029c87ff19e9fba635864e064da646bc749fc1908a4af18f3",
+                "sha256:ce5b64dfe8d0cca407d88b0ee619d80d4215a2612c1af8c98a92180e7109f4b5",
+                "sha256:d58a5a71c4c37354f9e0c24c9c8321f0185f6945ef027460b809f4bb474bfe41",
+                "sha256:db41f3845eb579b544c962864cce2c2a0257fe30f0f1e18e51b1e8cbb4e0ac6d",
+                "sha256:db5b25265010a1b3dca6a174a443a0ed4c4ab12d5e2883a11c97d6e6d59b12f9",
+                "sha256:dd0404d154084a371e6d2bafc787201612a1359c2dee688ae334f9118aa0bf47",
+                "sha256:de431765bd5fe62119e0bc6bc6e7b17ac53017ae1782acf88fcf6b7eae475a49",
+                "sha256:df02fdec0c533301497acb0bc0f27f479a3a63dcdc3a099ae33a902857f07477",
+                "sha256:e8533f5111704d75de3139bf0b8136d3a6c1642c55c067866fa0a51c2155ee33",
+                "sha256:f2f908239b7098799b8845e5936c2ccb91d8c2323be02e82f8dcb4a80dcf4a25",
+                "sha256:f8bfd36f368efe0ab2a6aa3db7f14598aac454b06849fb633b762ddbede1db90",
+                "sha256:ffe73f9e7aea404722058405ff24041e59d31ca23d1da0895af48050a07b6932"
             ],
             "markers": "python_version >= '3' and platform_machine == 'aarch64' or (platform_machine == 'ppc64le' or (platform_machine == 'x86_64' or (platform_machine == 'amd64' or (platform_machine == 'AMD64' or (platform_machine == 'win32' or platform_machine == 'WIN32')))))",
-            "version": "==1.1.2"
+            "version": "==1.1.3"
         },
         "idna": {
             "hashes": [
-                "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
-                "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"
+                "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4",
+                "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"
             ],
             "markers": "python_version >= '3.5'",
-            "version": "==3.3"
+            "version": "==3.4"
         },
-        "importlib-metadata": {
+        "inflect": {
             "hashes": [
-                "sha256:637245b8bab2b6502fcbc752cc4b7a6f6243bb02b31c5c26156ad103d3d45670",
-                "sha256:7401a975809ea1fdc658c3aa4f78cc2195a0e019c5cbc4c06122884e9ae80c23"
+                "sha256:0bc1516ec2725e2d8221707a612245093cb6f1cea209cfd8cbd4fc5e96fa6365",
+                "sha256:e3b85d65a296843268f35f4136283ad7c012a129375db1529d49b4b01ecb400b"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==4.12.0"
-        },
-        "importlib-resources": {
-            "hashes": [
-                "sha256:5481e97fb45af8dcf2f798952625591c58fe599d0735d86b10f54de086a61681",
-                "sha256:f78a8df21a79bcc30cfd400bdc38f314333de7c0fb619763f6b9dabab8268bb7"
-            ],
-            "markers": "python_version < '3.9'",
-            "version": "==5.9.0"
+            "version": "==6.0.0"
         },
         "isodate": {
             "hashes": [
@@ -333,28 +315,18 @@
         },
         "jaraco.text": {
             "hashes": [
-                "sha256:450957c3f8fb9a553d9d3e60738733ab1c5cc27b36a463342adb937e9a70ab3e",
-                "sha256:e4418d632425d741b8f9128cdf8fd9c0c878dc1450a7430dbd4bf6296eeac915"
+                "sha256:3ca615c4135e151d21206075ec4aface8a2fbc3e68437fe709a6541428a635f9",
+                "sha256:d57cd4448a588020318425e04194e897f96fc23b92b82ff9308a24d5cbf2b3fb"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.8.1"
-        },
-        "keyring": {
-            "hashes": [
-                "sha256:4aa2521b8fccf602342c85fc2edcb0b9e055557a4fcdc28ce447c2d608e13abb",
-                "sha256:a6aa0af82bafa882810e2402cebe6b8152786cd6e4e4f0416b0f2c3bf0d043a4"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==23.8.0"
+            "version": "==3.9.1"
         },
         "libgutenberg": {
-            "extras": [
-                "postgres"
-            ],
             "hashes": [
-                "sha256:7978b0f33b2fcf44f535043503516e4a9133b6bf853319009777a0bfecb3dea7"
+                "sha256:ecf27e4bca5c265d1c37d2187ddec667079c96d53f5eb7e98555e3446754da22"
             ],
-            "version": "==0.10.0"
+            "index": "pypi",
+            "version": "==0.10.2"
         },
         "lxml": {
             "hashes": [
@@ -434,19 +406,19 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:a42901a0a5b169d925f6f217cd5a190e32ef54360905b9c39ee7db5313bfec0f",
-                "sha256:c5122bffc5f104d37c1626b8615b511f3427aa5389b94d61e5ef8236bfbc3ddb"
+                "sha256:1bc4f91ee5b1b31ac7ceacc17c09befe6a40a503907baf9c839c229b5095cfd2",
+                "sha256:c09443cd3d5438b8dafccd867a6bc1cb0894389e90cb53d227456b0b0bccb750"
             ],
             "markers": "python_version >= '3.5'",
-            "version": "==8.13.0"
+            "version": "==8.14.0"
         },
         "oauthlib": {
             "hashes": [
-                "sha256:23a8208d75b902797ea29fd31fa80a15ed9dc2c6c16fe73f5d346f83f6fa27a2",
-                "sha256:6db33440354787f9b7f3a6dbd4febf5d0f93758354060e802f6c06cb493022fe"
+                "sha256:1565237372795bf6ee3e5aba5e2a85bd5a65d0e2aa5c628b9a97b7d7a0da3721",
+                "sha256:88e912ca1ad915e1dcc1c06fc9259d19de8deacd6fd17cc2df266decc2e49066"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==3.2.0"
+            "version": "==3.2.1"
         },
         "pillow": {
             "hashes": [
@@ -465,10 +437,10 @@
                 "sha256:2ad0d4df0f5ef2247e27fc790d5c9b5a0af8ade9ba340db4a73bb1a4a3e5fb4f",
                 "sha256:2c58b24e3a63efd22554c676d81b0e57f80e0a7d3a5874a7e14ce90ec40d3069",
                 "sha256:2d33a11f601213dcd5718109c09a52c2a1c893e7461f0be2d6febc2879ec2402",
+                "sha256:336b9036127eab855beec9662ac3ea13a4544a523ae273cbf108b228ecac8437",
                 "sha256:337a74fd2f291c607d220c793a8135273c4c2ab001b03e601c36766005f36885",
                 "sha256:37ff6b522a26d0538b753f0b4e8e164fdada12db6c6f00f62145d732d8a3152e",
                 "sha256:3d1f14f5f691f55e1b47f824ca4fdcb4b19b4323fe43cc7bb105988cad7496be",
-                "sha256:408673ed75594933714482501fe97e055a42996087eeca7e5d06e33218d05aa8",
                 "sha256:4134d3f1ba5f15027ff5c04296f13328fecd46921424084516bdb1b2548e66ff",
                 "sha256:4ad2f835e0ad81d1689f1b7e3fbac7b01bb8777d5a985c8962bedee0cc6d43da",
                 "sha256:50dff9cc21826d2977ef2d2a205504034e3a4563ca6f5db739b0d1026658e004",
@@ -477,7 +449,6 @@
                 "sha256:69bd1a15d7ba3694631e00df8de65a8cb031911ca11f44929c97fe05eb9b6c1d",
                 "sha256:6bf088c1ce160f50ea40764f825ec9b72ed9da25346216b91361eef8ad1b8f8c",
                 "sha256:6e8c66f70fb539301e064f6478d7453e820d8a2c631da948a23384865cd95544",
-                "sha256:727dd1389bc5cb9827cbd1f9d40d2c2a1a0c9b32dd2261db522d22a604a6eec9",
                 "sha256:74a04183e6e64930b667d321524e3c5361094bb4af9083db5c301db64cd341f3",
                 "sha256:75e636fd3e0fb872693f23ccb8a5ff2cd578801251f3a4f6854c6a5d437d3c04",
                 "sha256:7761afe0126d046974a01e030ae7529ed0ca6a196de3ec6937c11df0df1bc91c",
@@ -493,6 +464,7 @@
                 "sha256:a647c0d4478b995c5e54615a2e5360ccedd2f85e70ab57fbe817ca613d5e63b8",
                 "sha256:a9c9bc489f8ab30906d7a85afac4b4944a572a7432e00698a7239f44a44e6efb",
                 "sha256:ad2277b185ebce47a63f4dc6302e30f05762b688f8dc3de55dbae4651872cdf3",
+                "sha256:adabc0bce035467fb537ef3e5e74f2847c8af217ee0be0455d4fec8adc0462fc",
                 "sha256:b6d5e92df2b77665e07ddb2e4dbd6d644b78e4c0d2e9272a852627cdba0d75cf",
                 "sha256:bc431b065722a5ad1dfb4df354fb9333b7a582a5ee39a90e6ffff688d72f27a1",
                 "sha256:bdd0de2d64688ecae88dd8935012c4a72681e5df632af903a1dca8c5e7aa871a",
@@ -511,14 +483,6 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==9.2.0"
-        },
-        "pkginfo": {
-            "hashes": [
-                "sha256:848865108ec99d4901b2f7e84058b6e7660aae8ae10164e015a6dcf5b242a594",
-                "sha256:a84da4318dd86f870a9447a8c98340aa06216bfc6f2b7bdc4b8766984ae1867c"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.8.3"
         },
         "portend": {
             "hashes": [
@@ -558,13 +522,47 @@
             ],
             "version": "==2.21"
         },
-        "pygments": {
+        "pydantic": {
             "hashes": [
-                "sha256:5eb116118f9612ff1ee89ac96437bb6b49e8f04d8a13b514ba26f620208e26eb",
-                "sha256:dc9c10fb40944260f6ed4c688ece0cd2048414940f1cea51b8b226318411c519"
+                "sha256:05e00dbebbe810b33c7a7362f231893183bcc4251f3f2ff991c31d5c08240c42",
+                "sha256:06094d18dd5e6f2bbf93efa54991c3240964bb663b87729ac340eb5014310624",
+                "sha256:0b959f4d8211fc964772b595ebb25f7652da3f22322c007b6fed26846a40685e",
+                "sha256:19b3b9ccf97af2b7519c42032441a891a5e05c68368f40865a90eb88833c2559",
+                "sha256:1b6ee725bd6e83ec78b1aa32c5b1fa67a3a65badddde3976bca5fe4568f27709",
+                "sha256:1ee433e274268a4b0c8fde7ad9d58ecba12b069a033ecc4645bb6303c062d2e9",
+                "sha256:216f3bcbf19c726b1cc22b099dd409aa371f55c08800bcea4c44c8f74b73478d",
+                "sha256:2d0567e60eb01bccda3a4df01df677adf6b437958d35c12a3ac3e0f078b0ee52",
+                "sha256:2e05aed07fa02231dbf03d0adb1be1d79cabb09025dd45aa094aa8b4e7b9dcda",
+                "sha256:352aedb1d71b8b0736c6d56ad2bd34c6982720644b0624462059ab29bd6e5912",
+                "sha256:355639d9afc76bcb9b0c3000ddcd08472ae75318a6eb67a15866b87e2efa168c",
+                "sha256:37c90345ec7dd2f1bcef82ce49b6235b40f282b94d3eec47e801baf864d15525",
+                "sha256:4b8795290deaae348c4eba0cebb196e1c6b98bdbe7f50b2d0d9a4a99716342fe",
+                "sha256:5760e164b807a48a8f25f8aa1a6d857e6ce62e7ec83ea5d5c5a802eac81bad41",
+                "sha256:6eb843dcc411b6a2237a694f5e1d649fc66c6064d02b204a7e9d194dff81eb4b",
+                "sha256:7b5ba54d026c2bd2cb769d3468885f23f43710f651688e91f5fb1edcf0ee9283",
+                "sha256:7c2abc4393dea97a4ccbb4ec7d8658d4e22c4765b7b9b9445588f16c71ad9965",
+                "sha256:81a7b66c3f499108b448f3f004801fcd7d7165fb4200acb03f1c2402da73ce4c",
+                "sha256:91b8e218852ef6007c2b98cd861601c6a09f1aa32bbbb74fab5b1c33d4a1e410",
+                "sha256:9300fcbebf85f6339a02c6994b2eb3ff1b9c8c14f502058b5bf349d42447dcf5",
+                "sha256:9cabf4a7f05a776e7793e72793cd92cc865ea0e83a819f9ae4ecccb1b8aa6116",
+                "sha256:a1f5a63a6dfe19d719b1b6e6106561869d2efaca6167f84f5ab9347887d78b98",
+                "sha256:a4c805731c33a8db4b6ace45ce440c4ef5336e712508b4d9e1aafa617dc9907f",
+                "sha256:ae544c47bec47a86bc7d350f965d8b15540e27e5aa4f55170ac6a75e5f73b644",
+                "sha256:b97890e56a694486f772d36efd2ba31612739bc6f3caeee50e9e7e3ebd2fdd13",
+                "sha256:bb6ad4489af1bac6955d38ebcb95079a836af31e4c4f74aba1ca05bb9f6027bd",
+                "sha256:bedf309630209e78582ffacda64a21f96f3ed2e51fbf3962d4d488e503420254",
+                "sha256:c1ba1afb396148bbc70e9eaa8c06c1716fdddabaf86e7027c5988bae2a829ab6",
+                "sha256:c33602f93bfb67779f9c507e4d69451664524389546bacfe1bee13cae6dc7488",
+                "sha256:c4aac8e7103bf598373208f6299fa9a5cfd1fc571f2d40bf1dd1955a63d6eeb5",
+                "sha256:c6f981882aea41e021f72779ce2a4e87267458cc4d39ea990729e21ef18f0f8c",
+                "sha256:cc78cc83110d2f275ec1970e7a831f4e371ee92405332ebfe9860a715f8336e1",
+                "sha256:d49f3db871575e0426b12e2f32fdb25e579dea16486a26e5a0474af87cb1ab0a",
+                "sha256:dd3f9a40c16daf323cf913593083698caee97df2804aa36c4b3175d5ac1b92a2",
+                "sha256:e0bedafe4bc165ad0a56ac0bd7695df25c50f76961da29c050712596cf092d6d",
+                "sha256:e9069e1b01525a96e6ff49e25876d90d5a563bc31c658289a8772ae186552236"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==2.12.0"
+            "markers": "python_version >= '3.7'",
+            "version": "==1.10.2"
         },
         "pyparsing": {
             "hashes": [
@@ -576,10 +574,10 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:1e760e2fe6a8163bc0b3d9a19c4f84342afa0a2affebfaa84b01b978a02ecaa7",
-                "sha256:e68985985296d9a66a881eb3193b0906246245294a881e7c8afe623866ac6a5c"
+                "sha256:220f481bdafa09c3955dfbdddb7b57780e9a94f5127e35456a48589b9e0c0197",
+                "sha256:cea221417204f2d1a2aa03ddae3e867921971d0d76f14d87abb4414415bbdcf5"
             ],
-            "version": "==2022.1"
+            "version": "==2022.2.1"
         },
         "qrcode": {
             "hashes": [
@@ -596,14 +594,6 @@
             "markers": "python_version >= '3.7'",
             "version": "==6.2.0"
         },
-        "readme-renderer": {
-            "hashes": [
-                "sha256:2c37e472ca96755caba6cc58bcbf673a5574bc033385a2ac91d85dfef2799876",
-                "sha256:f71aeef9a588fcbed1f4cc001ba611370e94a0cd27c75b1140537618ec78f0a2"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==36.0"
-        },
         "requests": {
             "hashes": [
                 "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983",
@@ -619,29 +609,6 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.3.1"
-        },
-        "requests-toolbelt": {
-            "hashes": [
-                "sha256:380606e1d10dc85c3bd47bf5a6095f815ec007be7a8b69c878507068df059e6f",
-                "sha256:968089d4584ad4ad7c171454f0a5c6dac23971e9472521ea3b6d49d610aa6fc0"
-            ],
-            "version": "==0.9.1"
-        },
-        "rfc3986": {
-            "hashes": [
-                "sha256:50b1502b60e289cb37883f3dfd34532b8873c7de9f49bb546641ce9cbd256ebd",
-                "sha256:97aacf9dbd4bfd829baad6e6309fa6573aaf1be3f6fa735c8ab05e46cecb261c"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==2.0.0"
-        },
-        "rich": {
-            "hashes": [
-                "sha256:2eb4e6894cde1e017976d2975ac210ef515d7548bc595ba20e195fb9628acdeb",
-                "sha256:63a5c5ce3673d3d5fbbf23cd87e11ab84b6b451436f1b7f19ec54b6bc36ed7ca"
-            ],
-            "markers": "python_version < '4' and python_full_version >= '3.6.3'",
-            "version": "==12.5.1"
         },
         "roman": {
             "hashes": [
@@ -660,11 +627,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:73bfae4791da7c1c56882ab17577d00f7a37a0347162aeb9360058de0dc25083",
-                "sha256:abcb76aa4decd7a17cbe0e4b31bdf549d106ba7f668e87e0860f5f7b84b9b3fe"
+                "sha256:2e24e0bec025f035a2e72cdd1961119f557d78ad331bb00ff82efb2ab8da8e82",
+                "sha256:7732871f4f7fa58fb6bdcaeadb0161b2bd046c85905dbaa066bdcbcc81953b57"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==63.4.2"
+            "version": "==65.3.0"
         },
         "six": {
             "hashes": [
@@ -684,45 +651,50 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:047ef5ccd8860f6147b8ac6c45a4bc573d4e030267b45d9a1c47b55962ff0e6f",
-                "sha256:05a05771617bfa723ba4cef58d5b25ac028b0d68f28f403edebed5b8243b3a87",
-                "sha256:0ec54460475f0c42512895c99c63d90dd2d9cbd0c13491a184182e85074b04c5",
-                "sha256:107df519eb33d7f8e0d0d052128af2f25066c1a0f6b648fd1a9612ab66800b86",
-                "sha256:14ea8ff2d33c48f8e6c3c472111d893b9e356284d1482102da9678195e5a8eac",
-                "sha256:1745987ada1890b0e7978abdb22c133eca2e89ab98dc17939042240063e1ef21",
-                "sha256:1962dfee37b7fb17d3d4889bf84c4ea08b1c36707194c578f61e6e06d12ab90f",
-                "sha256:20bf65bcce65c538e68d5df27402b39341fabeecf01de7e0e72b9d9836c13c52",
-                "sha256:26146c59576dfe9c546c9f45397a7c7c4a90c25679492ff610a7500afc7d03a6",
-                "sha256:365b75938049ae31cf2176efd3d598213ddb9eb883fbc82086efa019a5f649df",
-                "sha256:4770eb3ba69ec5fa41c681a75e53e0e342ac24c1f9220d883458b5596888e43a",
-                "sha256:50e7569637e2e02253295527ff34666706dbb2bc5f6c61a5a7f44b9610c9bb09",
-                "sha256:5c2d19bfb33262bf987ef0062345efd0f54c4189c2d95159c72995457bf4a359",
-                "sha256:621f050e72cc7dfd9ad4594ff0abeaad954d6e4a2891545e8f1a53dcdfbef445",
-                "sha256:6d81de54e45f1d756785405c9d06cd17918c2eecc2d4262dc2d276ca612c2f61",
-                "sha256:6f95706da857e6e79b54c33c1214f5467aab10600aa508ddd1239d5df271986e",
-                "sha256:752ef2e8dbaa3c5d419f322e3632f00ba6b1c3230f65bc97c2ff5c5c6c08f441",
-                "sha256:7b2785dd2a0c044a36836857ac27310dc7a99166253551ee8f5408930958cc60",
-                "sha256:7f13644b15665f7322f9e0635129e0ef2098409484df67fcd225d954c5861559",
-                "sha256:8194896038753b46b08a0b0ae89a5d80c897fb601dd51e243ed5720f1f155d27",
-                "sha256:864d4f89f054819cb95e93100b7d251e4d114d1c60bc7576db07b046432af280",
-                "sha256:8b773c9974c272aae0fa7e95b576d98d17ee65f69d8644f9b6ffc90ee96b4d19",
-                "sha256:8f901be74f00a13bf375241a778455ee864c2c21c79154aad196b7a994e1144f",
-                "sha256:91d2b89bb0c302f89e753bea008936acfa4e18c156fb264fe41eb6bbb2bbcdeb",
-                "sha256:b0538b66f959771c56ff996d828081908a6a52a47c5548faed4a3d0a027a5368",
-                "sha256:b30e70f1594ee3c8902978fd71900d7312453922827c4ce0012fa6a8278d6df4",
-                "sha256:b71be98ef6e180217d1797185c75507060a57ab9cd835653e0112db16a710f0d",
-                "sha256:c6d00cb9da8d0cbfaba18cad046e94b06de6d4d0ffd9d4095a3ad1838af22528",
-                "sha256:d1f665e50592caf4cad3caed3ed86f93227bffe0680218ccbb293bd5a6734ca8",
-                "sha256:e6e2c8581c6620136b9530137954a8376efffd57fe19802182c7561b0ab48b48",
-                "sha256:e7a7667d928ba6ee361a3176e1bef6847c1062b37726b33505cc84136f657e0d",
-                "sha256:ec3985c883d6d217cf2013028afc6e3c82b8907192ba6195d6e49885bfc4b19d",
-                "sha256:ede13a472caa85a13abe5095e71676af985d7690eaa8461aeac5c74f6600b6c0",
-                "sha256:f24d4d6ec301688c59b0c4bb1c1c94c5d0bff4ecad33bb8f5d9efdfb8d8bc925",
-                "sha256:f2a42acc01568b9701665e85562bbff78ec3e21981c7d51d56717c22e5d3d58b",
-                "sha256:fbc076f79d830ae4c9d49926180a1140b49fa675d0f0d555b44c9a15b29f4c80"
+                "sha256:0002e829142b2af00b4eaa26c51728f3ea68235f232a2e72a9508a3116bd6ed0",
+                "sha256:0005bd73026cd239fc1e8ccdf54db58b6193be9a02b3f0c5983808f84862c767",
+                "sha256:0292f70d1797e3c54e862e6f30ae474014648bc9c723e14a2fda730adb0a9791",
+                "sha256:036d8472356e1d5f096c5e0e1a7e0f9182140ada3602f8fff6b7329e9e7cfbcd",
+                "sha256:05f0de3a1dc3810a776275763764bb0015a02ae0f698a794646ebc5fb06fad33",
+                "sha256:0990932f7cca97fece8017414f57fdd80db506a045869d7ddf2dda1d7cf69ecc",
+                "sha256:13e397a9371ecd25573a7b90bd037db604331cf403f5318038c46ee44908c44d",
+                "sha256:14576238a5f89bcf504c5f0a388d0ca78df61fb42cb2af0efe239dc965d4f5c9",
+                "sha256:199a73c31ac8ea59937cc0bf3dfc04392e81afe2ec8a74f26f489d268867846c",
+                "sha256:2082a2d2fca363a3ce21cfa3d068c5a1ce4bf720cf6497fb3a9fc643a8ee4ddd",
+                "sha256:22ff16cedab5b16a0db79f1bc99e46a6ddececb60c396562e50aab58ddb2871c",
+                "sha256:2307495d9e0ea00d0c726be97a5b96615035854972cc538f6e7eaed23a35886c",
+                "sha256:2ad2b727fc41c7f8757098903f85fafb4bf587ca6605f82d9bf5604bd9c7cded",
+                "sha256:2d6495f84c4fd11584f34e62f9feec81bf373787b3942270487074e35cbe5330",
+                "sha256:361f6b5e3f659e3c56ea3518cf85fbdae1b9e788ade0219a67eeaaea8a4e4d2a",
+                "sha256:3e2ef592ac3693c65210f8b53d0edcf9f4405925adcfc031ff495e8d18169682",
+                "sha256:4676d51c9f6f6226ae8f26dc83ec291c088fe7633269757d333978df78d931ab",
+                "sha256:4ba7e122510bbc07258dc42be6ed45997efdf38129bde3e3f12649be70683546",
+                "sha256:5102fb9ee2c258a2218281adcb3e1918b793c51d6c2b4666ce38c35101bb940e",
+                "sha256:5323252be2bd261e0aa3f33cb3a64c45d76829989fa3ce90652838397d84197d",
+                "sha256:58bb65b3274b0c8a02cea9f91d6f44d0da79abc993b33bdedbfec98c8440175a",
+                "sha256:59bdc291165b6119fc6cdbc287c36f7f2859e6051dd923bdf47b4c55fd2f8bd0",
+                "sha256:5facb7fd6fa8a7353bbe88b95695e555338fb038ad19ceb29c82d94f62775a05",
+                "sha256:639e1ae8d48b3c86ffe59c0daa9a02e2bfe17ca3d2b41611b30a0073937d4497",
+                "sha256:8eb8897367a21b578b26f5713833836f886817ee2ffba1177d446fa3f77e67c8",
+                "sha256:90484a2b00baedad361402c257895b13faa3f01780f18f4a104a2f5c413e4536",
+                "sha256:9c56e19780cd1344fcd362fd6265a15f48aa8d365996a37fab1495cae8fcd97d",
+                "sha256:b67fc780cfe2b306180e56daaa411dd3186bf979d50a6a7c2a5b5036575cbdbb",
+                "sha256:c0dcf127bb99458a9d211e6e1f0f3edb96c874dd12f2503d4d8e4f1fd103790b",
+                "sha256:c23d64a0b28fc78c96289ffbd0d9d1abd48d267269b27f2d34e430ea73ce4b26",
+                "sha256:ccfd238f766a5bb5ee5545a62dd03f316ac67966a6a658efb63eeff8158a4bbf",
+                "sha256:cd767cf5d7252b1c88fcfb58426a32d7bd14a7e4942497e15b68ff5d822b41ad",
+                "sha256:ce8feaa52c1640de9541eeaaa8b5fb632d9d66249c947bb0d89dd01f87c7c288",
+                "sha256:d2e054aed4645f9b755db85bc69fc4ed2c9020c19c8027976f66576b906a74f1",
+                "sha256:e16c2be5cb19e2c08da7bd3a87fed2a0d4e90065ee553a940c4fc1a0fb1ab72b",
+                "sha256:e4b12e3d88a8fffd0b4ca559f6d4957ed91bd4c0613a4e13846ab8729dc5c251",
+                "sha256:e570cfc40a29d6ad46c9aeaddbdcee687880940a3a327f2c668dd0e4ef0a441d",
+                "sha256:eb30cf008850c0a26b72bd1b9be6730830165ce049d239cfdccd906f2685f892",
+                "sha256:f37fa70d95658763254941ddd30ecb23fc4ec0c5a788a7c21034fc2305dab7cc",
+                "sha256:f5ebeeec5c14533221eb30bad716bc1fd32f509196318fb9caa7002c4a364e4c",
+                "sha256:f5fa526d027d804b1f85cdda1eb091f70bde6fb7d87892f6dd5a48925bc88898"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.4.39"
+            "version": "==1.4.41"
         },
         "tempora": {
             "hashes": [
@@ -732,36 +704,21 @@
             "markers": "python_version >= '3.7'",
             "version": "==5.0.2"
         },
-        "twine": {
-            "hashes": [
-                "sha256:42026c18e394eac3e06693ee52010baa5313e4811d5a11050e7d48436cf41b9e",
-                "sha256:96b1cf12f7ae611a4a40b6ae8e9570215daff0611828f5fe1f37a16255ab24a0"
-            ],
-            "index": "pypi",
-            "version": "==4.0.1"
-        },
         "typing-extensions": {
             "hashes": [
                 "sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02",
                 "sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6"
             ],
-            "markers": "python_version < '3.9'",
+            "markers": "python_version >= '3.7'",
             "version": "==4.3.0"
         },
         "urllib3": {
             "hashes": [
-                "sha256:c33ccba33c819596124764c23a97d25f32b28433ba0dedeb77d873a38722c9bc",
-                "sha256:ea6e8fb210b19d950fab93b60c9009226c63a28808bc8386e05301e25883ac0a"
+                "sha256:3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e",
+                "sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4'",
-            "version": "==1.26.11"
-        },
-        "webencodings": {
-            "hashes": [
-                "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78",
-                "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"
-            ],
-            "version": "==0.5.1"
+            "version": "==1.26.12"
         },
         "zc.lockfile": {
             "hashes": [
@@ -769,14 +726,6 @@
                 "sha256:cc33599b549f0c8a248cb72f3bf32d77712de1ff7ee8814312eb6456b42c015f"
             ],
             "version": "==2.0"
-        },
-        "zipp": {
-            "hashes": [
-                "sha256:05b45f1ee8f807d0cc928485ca40a07cb491cf092ff587c0df9cb1fd154848d2",
-                "sha256:47c40d7fe183a6f21403a199b3e4192cca5774656965b0a4988ad2f8feb5f009"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==3.8.1"
         }
     },
     "develop": {}

--- a/ebookconverter/EbookConverter.py
+++ b/ebookconverter/EbookConverter.py
@@ -113,18 +113,15 @@ FILENAMES = {
     'txt.utf-8':        'pg{id}.txt.utf8',
     'rdf':              'pg{id}.rdf',
     'rst.gen':          'pg{id}.rst.utf8',
-    'twitter':          'pg{id}.twitter',            # FIXME: do we need these?
-    'facebook':         'pg{id}.facebook',           #
-    'picsdir.noimages': 'pg{id}-noimages.picsdir',   #
-    'picsdir.images':   'pg{id}-images.picsdir',     #
     'cover.small':      'pg{id}.cover.small.jpg',
     'cover.medium':     'pg{id}.cover.medium.jpg',
     'qrcode':           'pg{id}.qrcode.png',
     'logfile':          'pg{id}.converter.log',      # .converter because of latex log conflicts
 }
+GENERIC_FILENAME = 'pg{id}.generic'
 
 DEPENDENCIES = collections.OrderedDict((
-    ('everything',      ('all', 'facebook', 'twitter')),
+    ('everything',      ('all', 'kindle.noimages','facebook', 'twitter', 'update')),
     ('all',             ('html', 'epub', 'kindle', 'epub3', 'kf8', 'pdf', 'txt', 'rst',
                          'cover', 'qrcode', 'rdf')),
     ('html',            ('html.images',    'html.noimages')),
@@ -164,7 +161,7 @@ null
 def make_output_filename(type_, ebook = 0):
     """ Make a suitable filename for output type. """
 
-    return FILENAMES[type_].format(id = ebook)
+    return FILENAMES.get(type_, GENERIC_FILENAME).format(id = ebook)
 
 
 class Maker(object):
@@ -369,7 +366,7 @@ def run_job_queue(job_queue):
                 for ext in ['.gz', '.gzip']:
                     if os.access(filename + ext, os.W_OK):
                         os.remove(filename + ext)
-            elif filename.split('.')[-1] not in {'facebook', 'twitter', 'picsdir'}:
+            elif '.generic' not in filename:
                 critical('Failed to build file: %s', filename)
     else:
         critical('returncode was %s', ebm.returncode)

--- a/ebookconverter/EbookConverter.py
+++ b/ebookconverter/EbookConverter.py
@@ -130,7 +130,7 @@ DEPENDENCIES = collections.OrderedDict((
     ('html',            ('html.images',    'html.noimages')),
     ('epub',            ('epub.images',    'epub.noimages')),
     ('epub3',           ('epub3.images', )),
-    ('kindle',          ('kindle.images',  'kindle.noimages')),
+    ('kindle',          ('kindle.images')),
     ('kf8',             ('kf8.images', )),
     ('pdf',             ('pdf.images',     'pdf.noimages')),
     ('txt',             ('txt.utf-8',      'txt.iso-8859-1', 'txt.us-ascii')),

--- a/ebookconverter/EbookConverter.py
+++ b/ebookconverter/EbookConverter.py
@@ -80,6 +80,7 @@ PREFERRED_INPUT_FORMATS = {
     'qrcode': ('rst/*', 'html/*', 'txt/*', 'tex/*'),
     'facebook': ('rst/*', 'html/*', 'txt/*', 'tex/*'),
     'twitter': ('rst/*', 'html/*', 'txt/*', 'tex/*'),
+    'update': ('rst/*', 'html/*', 'txt/*', 'tex/*'),
 }
 
 PREFERRED_INPUT_FORMATS['html.noimages']      = PREFERRED_INPUT_FORMATS['html.images']
@@ -155,6 +156,7 @@ epub.images kindle.images pdf.images
 epub3.images kf8.images
 qrcode rdf
 facebook twitter
+update
 null
 """.split()
 

--- a/ebookconverter/EbookConverter.py
+++ b/ebookconverter/EbookConverter.py
@@ -127,7 +127,7 @@ DEPENDENCIES = collections.OrderedDict((
     ('html',            ('html.images',    'html.noimages')),
     ('epub',            ('epub.images',    'epub.noimages')),
     ('epub3',           ('epub3.images', )),
-    ('kindle',          ('kindle.images')),
+    ('kindle',          ('kindle.images',)),
     ('kf8',             ('kf8.images', )),
     ('pdf',             ('pdf.images',     'pdf.noimages')),
     ('txt',             ('txt.utf-8',      'txt.iso-8859-1', 'txt.us-ascii')),

--- a/ebookconverter/EbookConverter.py
+++ b/ebookconverter/EbookConverter.py
@@ -280,8 +280,11 @@ class Maker(object):
                 if job.maintype == 'txt' and candidate.extent > 8 * 1024 * 1024:
                     warning('Skipping %s: file too big' % candidate.archive_path)
                     continue
-                if job.maintype != 'kindle' and candidate.extent > 32 * 1024 * 1024:
-                    # the candidates for kindle, epubs, can get quite big
+                if job.maintype in ['epub', 'epub3'] and candidate.extent > 16 * 1024 * 1024:
+                    warning('Skipping %s: file too big' % candidate.archive_path)
+                    continue
+                if job.maintype != 'kf8' and candidate.extent > 32 * 1024 * 1024:
+                    # the candidates for kf8, epubs, can get quite big
                     warning('Skipping %s: file too big' % candidate.archive_path)
                     continue
 

--- a/ebookconverter/EbookConverter.py
+++ b/ebookconverter/EbookConverter.py
@@ -348,6 +348,8 @@ def run_job_queue(job_queue):
     debug(stderr.decode(sys.stderr.encoding))
     if ebm.returncode == 0:
         for job in job_queue:
+            if job.type == 'qrcode':
+                continue
             filename = os.path.join(job.outputdir, job.outputfile)
             Logger.ebook = job.ebook
             if os.access(filename, os.R_OK):

--- a/ebookconverter/EbookConverter.py
+++ b/ebookconverter/EbookConverter.py
@@ -164,7 +164,7 @@ def make_output_filename(type_, ebook = 0):
     return FILENAMES.get(type_, GENERIC_FILENAME).format(id = ebook)
 
 
-class Maker(object):
+class Maker():
     """ Helper class """
 
     def __init__(self, ebook):
@@ -584,7 +584,7 @@ def main():
     except ValueError:
         info("Not running: pidfile exists.")
         sys.exit(2)
-        
+
 
     if options.goback:
         interval = datetime.datetime.now() - datetime.timedelta(hours=options.goback)

--- a/ebookconverter/FileInfo.py
+++ b/ebookconverter/FileInfo.py
@@ -55,7 +55,7 @@ FILES = os.path.join(PUBLIC, 'files')
 FTP   = '/public/ftp/pub/docs/books/gutenberg/'
 
 PARSEABLE_FILES = '.rst .html .htm .tex .txt'.split ()
-HTML_FILES = '.html .htm'.split ()
+HTML_FILES = '.html .htm .xhtml'.split ()
 
 
 

--- a/ebookconverter/UpdateFromWorkflow.py
+++ b/ebookconverter/UpdateFromWorkflow.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+#  -*- mode: python; indent-tabs-mode: nil; -*- coding: UTF8 -*-
+
+"""
+UpdateFromWorkflow.py
+
+Copyright 2022 by Eric Hellman and Project Gutenberg
+Distributable under the GNU General Public License Version 3 or newer.
+scans the backup folder and adds possibly unloaded data.
+"""
+
+import os
+import json
+import re
+import stat
+
+from libgutenberg import Logger
+from libgutenberg.DublinCore import handle_dc_languages
+from libgutenberg.DublinCoreMapping import DublinCoreObject
+from libgutenberg.GutenbergGlobals import Struct
+
+from ebookconverter.FileInfo import get_workflow_file, WORKFLOW_LOG_DIR
+
+WORKFLOW_BACKUP_DIR = os.path.join(WORKFLOW_LOG_DIR, 'backup')
+
+
+def update_from_workflow(dc, record):
+    # check if there's a pubinfo, if so, don't update it.
+    has_pubinfo = dc.pubinfo and bool(
+        dc.pubinfo.publisher or dc.pubinfo.country or dc.pubinfo.years)
+    changed = False
+    if not has_pubinfo and (not dc.languages or dc.languages[0].id == 'en'):
+        set_lang = record.get('LANGUAGE', None)
+        if set_lang:
+            handle_dc_languages(dc, set_lang)
+            changed = True
+    if not has_pubinfo:
+        dc.pubinfo.publisher = record.get('PUBLISHER', None)
+        changed = changed or bool(dc.pubinfo.publisher)
+        dc.pubinfo.country = record.get('PUBLISHER_COUNTRY', None)
+        changed = changed or bool(dc.pubinfo.country)
+        value = record.get('SOURCE_PUBLICATION_YEARS', None)
+        if value:
+            value = [value] if isinstance(value, str) else value
+            if isinstance(value, list):
+                for event_year in value:
+                    if ':' in event_year:
+                        [event, year] = event_year.split(':')
+                        dc.pubinfo.years.append((event, year))
+                    elif event_year:
+                        dc.pubinfo.years.append(('copyright', year))
+                changed = True
+    if not dc.scan_urls:
+        value = record.get('SCANS_ARCHIVE_URL', None)
+        if value:
+            if isinstance(value, str):
+                value = [value]
+            if isinstance(value, list):
+                for scan_url in value:
+                    dc.scan_urls.add(scan_url)
+                changed = True
+    if not dc.request_key:
+        dc.request_key = record.get('REQUEST_KEY', None)
+        changed = changed or bool(dc.request_key)
+    if not dc.credit:
+        dc.credit = record.get('CREDIT', None)
+        changed = changed or bool(dc.credit)
+    if changed:
+        dc.save(updatemode=1)
+        Logger.info('updated #%s', dc.project_gutenberg_id)
+
+
+def main():
+    Logger.setup(Logger.LOGFORMAT, 'fileinfo.log')
+    Logger.set_log_level(2)
+
+    for filename in sorted(os.listdir(WORKFLOW_BACKUP_DIR)):
+        workflow_file = os.path.join(WORKFLOW_BACKUP_DIR, filename)
+        mode = os.stat(workflow_file)[stat.ST_MODE]
+        if stat.S_ISDIR(mode):
+            continue
+        ebook_num = 0
+        m = re.match(r'^(\d+)\.json$', filename)
+        if m:
+            ebook_num = int(m.group(1))
+            Logger.ebook = ebook_num
+        else:
+            continue
+
+        with open(workflow_file, 'r') as fp:
+            wf_data = fp.read()
+        data = json.loads(wf_data)
+        record = data['DATA']
+
+        dc = DublinCoreObject()
+        dc.load_from_database(ebook_num)
+        if dc.book:
+            update_from_workflow(dc, record)
+
+if __name__ == '__main__':
+    main()

--- a/ebookconverter/Version.py
+++ b/ebookconverter/Version.py
@@ -1,1 +1,1 @@
-VERSION = '0.8.1'
+VERSION = '0.8.2'

--- a/ebookconverter/Version.py
+++ b/ebookconverter/Version.py
@@ -1,1 +1,1 @@
-VERSION = '0.8.0'
+VERSION = '0.8.1'

--- a/ebookconverter/writers/UpdateWriter.py
+++ b/ebookconverter/writers/UpdateWriter.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+#  -*- mode: python; indent-tabs-mode: nil; -*- coding: UTF8 -*-
+
+"""
+
+CoverpageWriter.py
+
+Copyright 2022 by Eric Hellman and Project Gutenberg
+
+Distributable under the GNU General Public License Version 3 or newer.
+
+Write metadata from source files to the database
+
+"""
+from lxml import etree
+
+from libgutenberg.DublinCore import GutenbergDublinCore
+from libgutenberg.Logger import info, exception
+
+from ebookmaker import writers
+
+
+class Writer(writers.BaseWriter):
+    """ Class that checks the main file for a book if the db lacks a record. """
+
+
+    def build(self, job):
+        """ checking files for credit metadata """
+
+        try:
+            info(etree.tostring(job.dc.to_html()))
+            if not bool(job.dc.credit):
+                info("Checking credit metadata in file for %s" % job.ebook)
+                file_dc = GutenbergDublinCore()
+                file_dc.load_from_parser(job.spider.parsers[0])
+                info(etree.tostring(file_dc.to_html()))
+                if file_dc.credit:
+                    job.dc.credit = file_dc.credit
+                    job.dc.save(updatemode=1)
+                    info("set credit for  %s", job.ebook)
+                    return
+                info("no credit metadata in %s", job.url)
+
+        except Exception as what:
+            exception ("Error checking metadata: %s" % what)
+            raise

--- a/scripts/update_from_backup_workflow
+++ b/scripts/update_from_backup_workflow
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+#  -*- mode: python; indent-tabs-mode: nil; -*- coding: UTF8 -*-
+
+"""
+
+fileinfo script
+
+Distributable under the GNU General Public License Version 3 or newer.
+
+This script runs UpdateFromWorkflow.
+
+"""
+
+from ebookconverter import UpdateFromWorkflow
+
+UpdateFromWorkflow.main()

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup (
         'scripts/fileinfo',
         'scripts/make_csv',
         'scripts/reload_workflow',
+        'scripts/update_from_backup_workflow',
         'scripts/cron-rebuild-files.sh',
         'scripts/cron-dopush-social.sh',
         'scripts/cron-dopush.sh',
@@ -33,7 +34,7 @@ setup (
         'requests_oauthlib>=1.2.0',
         'rdflib>=4.2.2',
         'qrcode>=6.1',
-        'libgutenberg[postgres]>=0.10.0',
+        'libgutenberg[postgres]>=0.10.2',
     ],
     
     package_data = {

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 
 from setuptools import setup
 
-VERSION = '0.8.0'
+VERSION = '0.8.1'
 
 setup (
     name = 'ebookconverter',

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup (
         'scripts/cron-rebuild-files.sh',
         'scripts/cron-dopush-social.sh',
         'scripts/cron-dopush.sh',
+        'scripts/cron-jekyll.sh',
     ],
 
     install_requires = [

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 
 from setuptools import setup
 
-VERSION = '0.8.1'
+VERSION = '0.8.2'
 
 setup (
     name = 'ebookconverter',
@@ -29,12 +29,12 @@ setup (
     ],
 
     install_requires = [
-        'ebookmaker>=0.12.0',
+        'ebookmaker>=0.12.14',
         'setproctitle==1.1.10',
         'requests_oauthlib>=1.2.0',
         'rdflib>=4.2.2',
         'qrcode>=6.1',
-        'libgutenberg[postgres]>=0.10.2',
+        'libgutenberg[postgres]>=0.10.4',
     ],
     
     package_data = {


### PR DESCRIPTION
- Adds UpdateWriter. It scans source files for metadata headers and adds to the database. Currently only looks for 'Credit:' or 'Produced by:'.
- `.xhtml` added to parseable file extensions
- stop producing kindle.noimages unless asked to
- add a "generic" file name for Writers that don't write (Twiter, Facebook, Update)
