### PR TITLE
Adding word count at build time

### DIFF
--- a/ebookconverter/EbookConverter.py
+++ b/ebookconverter/EbookConverter.py
@@ -84,6 +84,9 @@ PREFERRED_INPUT_FORMATS = {
     # readability score is computed from the text file
     'readability': ALL_TXTS,
 
+    # word count is computed from the text file
+    'wordcount': ALL_TXTS,
+
 }
 
 PREFERRED_INPUT_FORMATS['html.noimages']      = PREFERRED_INPUT_FORMATS['html.images']
@@ -125,7 +128,7 @@ GENERIC_FILENAME = 'pg{id}.generic'
 DEPENDENCIES = collections.OrderedDict((
     ('everything',      ('all', 'kindle.noimages','facebook', 'bluesky', 'mastodon', 'update', 'summary')),
     ('all',             ('html', 'epub', 'kindle', 'epub3', 'kf8', 'pdf', 'txt', 'rst',
-                         'cover', 'qrcode', 'rdf', 'readability')),
+                         'cover', 'qrcode', 'rdf', 'readability', 'wordcount')),
     ('html',            ('html.images',)),
     ('epub',            ('epub.images',    'epub.noimages')),
     ('epub3',           ('epub3.images',)),
@@ -154,7 +157,7 @@ epub.images kindle.images pdf.images
 epub3.images kf8.images
 qrcode rdf
 facebook bluesky mastodon
-update summary readability
+update summary readability wordcount
 null
 """.split()
 

--- a/ebookconverter/writers/WordCountWriter.py
+++ b/ebookconverter/writers/WordCountWriter.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+#  -*- mode: python; indent-tabs-mode: nil; -*- coding: utf-8 -*-
+
+# Counts the words in a book's text and stores the total as attribute 909 (for now).
+# Rather than naively splitting on spaces, we pick out the actual words, so that
+# stray punctuation and formatting marks aren't miscounted as words.
+
+
+import re
+
+from libgutenberg.GutenbergDatabase import DatabaseError
+from libgutenberg.Logger import exception, error, info, debug
+from libgutenberg.Models import Attribute
+from ebookmaker.writers import TxtWriter
+from ebookmaker.parsers.boilerplate import strip_headers_from_txt
+
+WORDCOUNT_ATTR = 909  # placeholder code -- Eric to confirm/replace
+
+# We match runs of letters/digits (keeping internal apostrophes and hyphens,
+# so "don't" and "mother-in-law" stay single words) instead of a plain split().
+# A naive split() gets fooled by PG plain text: em-dashes are glued between
+# words ("said--and"), and italics are marked with underscores ("_word_"), so
+# it would miscount. Matching word-runs sidesteps both and drops punctuation
+# and blank lines for free.
+WORD_RE = re.compile(r"[^\W_]+(?:['’-][^\W_]+)*")
+
+def is_non_text(book):
+    """Return True for non-text items (audio, images, data)."""
+    return book.categories != []
+
+
+class Writer (TxtWriter.Writer):
+    """ Word Count Writer Class. """
+
+    def build(self, job):
+        '''Count words in the book text and write the total to the database.'''
+        id = job.dc.project_gutenberg_id
+        if is_non_text(job.dc.book):
+            info ("WordCountWriter: Non-Text Job, Skipping Writing for %d" % id)
+            return
+        self.dc = job.dc
+
+        try:
+            # this should get the cached parser from our inherited TxtWriter
+            parser = TxtWriter.ParserFactory.ParserFactory.parsers[job.url]
+            # strip the PG license boilerplate so it isn't counted
+            book_content, _, _ = strip_headers_from_txt(parser.unicode_content())
+        except KeyError as kerr:
+            error ("WordCountWriter: Couldn't Access Text: %s" % kerr)
+            return
+        except UnicodeError as uerr:
+            error ("WordCountWriter: Bad Text Content: %s" % uerr)
+            return
+
+        count = len(WORD_RE.findall(book_content))
+        self.insert_into_pg_database(id, str(count))
+
+    def insert_into_pg_database(self, id, db_text):
+        '''Insert or update the word-count attribute (909).'''
+        session = self.dc.get_my_session()
+        existing = [a for a in self.dc.book.attributes if a.fk_attriblist == WORDCOUNT_ATTR]
+        try:
+            if existing:
+                existing[0].text = db_text
+                session.commit()
+                debug ("WordCountWriter: replaced count: %d" % id)
+                return
+            self.dc.book.attributes.append(Attribute(
+                fk_attriblist=WORDCOUNT_ATTR, text=db_text, nonfiling=0))
+            session.commit()
+            info ("WordCountWriter: created count: %d" % id)
+        except DatabaseError as dberr:
+            exception ('WordCountWriter: could not add count to database: %s' % (dberr))


### PR DESCRIPTION
Add `WordCountWriter` to compute total word counts and store them as DB attribute 909. Counts actual words rather than just splitting on whitespace, so that stray punctuation etc aren't miscounted. 909 is a placeholder code meant to be adapted to whatever gets decided on the DB front.