### PR TITLE
Adding Ebook Counter to Homepage

### DIFF
--- a/scripts/cron-jekyll.sh
+++ b/scripts/cron-jekyll.sh
@@ -27,6 +27,7 @@ OLDSUM=`/usr/bin/sum ${BUILD}/_includes/latest_covers.html | /usr/bin/cut -f1 -d
 # This is going to appdev:
 /usr/bin/wget --quiet -O ${BUILD}/_includes/latest_covers.html "http://[2610:28:3090:3001:0:dead:cafe:100]:8000/covers/medium/latest/10"
 /usr/bin/wget --quiet -O ${BUILD}/_includes/popular_covers.html "http://[2610:28:3090:3001:0:dead:cafe:100]:8000/covers/medium/popular/10"
+/usr/bin/wget --quiet -O ${BUILD}/_includes/book_count.html "http://[2610:28:3090:3001:0:dead:cafe:100]:8000/ebook_count/"
 
 # Are the covers different than previously?
 NEWSUM=`/usr/bin/sum ${BUILD}/_includes/latest_covers.html | /usr/bin/cut -f1 -d" "`

--- a/scripts/dev-jekyll.sh
+++ b/scripts/dev-jekyll.sh
@@ -16,6 +16,8 @@ git checkout remotes/origin/dev
 
 # Fetch input, the popular covers:
 /usr/bin/wget --quiet -O ${BUILD}/_includes/popular_covers.html "http://[2610:28:3090:3001:0:dead:cafe:100]:8000/covers/medium/popular/10"
+# Fetch input, the exact ebook count:
+/usr/bin/wget --quiet -O ${BUILD}/_includes/book_count.html "http://[2610:28:3090:3001:0:dead:cafe:100]:8000/ebook_count/"
 
 
 # This deploys the new content. Any errors will be returned; otherwise

--- a/scripts/prod-jekyll.sh
+++ b/scripts/prod-jekyll.sh
@@ -14,6 +14,8 @@ git checkout remotes/origin/master
 /usr/bin/wget --quiet -O ${BUILD}/_includes/latest_covers.html "http://[2610:28:3090:3001:0:dead:cafe:100]:8000/covers/medium/latest/10"
 # Fetch input, the popular covers:
 /usr/bin/wget --quiet -O ${BUILD}/_includes/popular_covers.html "http://[2610:28:3090:3001:0:dead:cafe:100]:8000/covers/medium/popular/10"
+# Fetch input, the exact ebook count:
+/usr/bin/wget --quiet -O ${BUILD}/_includes/book_count.html "http://[2610:28:3090:3001:0:dead:cafe:100]:8000/ebook_count/"
 
 
 


### PR DESCRIPTION
Adds a wget in all three jekyll build scripts to fetch autocat3's new "/ebook_count/" endpoint into "_includes/book_count.html". Sister PR for: gutenbergtools/autocat3#244 and gutenbergtools/gutenbergsite#314